### PR TITLE
fix: remove space from variables

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -82,7 +82,7 @@ func (r *JMeterRunner) Run(execution testkube.Execution) (result testkube.Execut
 	// compose parameters passed to JMeter with -J
 	params := make([]string, 0, len(execution.Variables))
 	for _, value := range execution.Variables {
-		params = append(params, fmt.Sprintf(" -J%s=%s", value.Name, value.Value))
+		params = append(params, fmt.Sprintf("-J%s=%s", value.Name, value.Value))
 	}
 
 	runPath := r.Params.Datadir


### PR DESCRIPTION
## Pull request description 

Using variables is throwing an error:
https://github.com/kubeshop/testkube/issues/2784
This PR fixes that.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-